### PR TITLE
fix(html-theme): Add support for UTF-8 characters (for non-English documentation)

### DIFF
--- a/views/layout/header.eta
+++ b/views/layout/header.eta
@@ -3,6 +3,7 @@ const {config, modules} = it;
 %>
 <html lang="en">
 <head>
+    <meta charset='UTF-8'>
     <title><%= config.title %></title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css">
     <style>


### PR DESCRIPTION
I tried to use this library in a production environment, but it was garbled. After checking, I found that the `<meta charset='UTF-8'>` was not added to the page, so I fixed it as I went along

Before restoration

![image](https://user-images.githubusercontent.com/24560368/107112890-eff29380-6895-11eb-9eb4-caabe16364fd.png)

After restoration

![image](https://user-images.githubusercontent.com/24560368/107112901-013ba000-6896-11eb-9ae3-b5609f3c82a4.png)
